### PR TITLE
fix(progress-bar): Progress bar of Updated files reach 100

### DIFF
--- a/fetcher/mitre.go
+++ b/fetcher/mitre.go
@@ -62,6 +62,7 @@ func (c Config) FetchMitreCti() (records []*models.Cti, err error) {
 		for _, m := range matched {
 			s := strings.Split(m, ":")
 			if ignoreJSON.MatchString(s[0]) {
+				bar.Increment()
 				continue
 			}
 			path := filepath.Join(dir, s[0])
@@ -131,13 +132,13 @@ func convertToModel(cveID string, item CapecObjects) (*models.Cti, error) {
 	}
 
 	return &models.Cti{
-		Name:             item.Name,
-		Type:             item.Type,
-		Description:      item.Description,
-		CveID:            cveID,
-		Capec:            &xcapec,
-		KillChains:       kills,
-		References:       refs,
+		Name:        item.Name,
+		Type:        item.Type,
+		Description: item.Description,
+		CveID:       cveID,
+		Capec:       &xcapec,
+		KillChains:  kills,
+		References:  refs,
 		// PublishedDate:    publish,
 		// LastModifiedDate: modified,
 	}, nil


### PR DESCRIPTION
This PR is an implementation of CVE-DB using threat intelligence, which will be used in **vuls** in the future.
The functions provided are as follows.

# What did you implement:

Progress bar didn"t reach 100% like bellow

```bash

INFO[06-15|15:34:50] Updated files                            count=17074                                                                                     
 397 / 757 [======================================================================>---------------------------------------------------------------]  52.44% 0s
 78 / 153 [====================================================================>------------------------------------------------------------------]  50.98% 0s

```

So, fix to reach 100% like bellow

```bash

INFO[06-15|15:39:34] Updated files                            count=17074                                                                                     
757 / 757 [======================================================================================================================================] 100.00% 0s 
153 / 153 [======================================================================================================================================] 100.00% 0s

```




# How Has This Been Tested?

Run main.go 

```bash
$ go run main.go fetch threat
EROR[06-15|15:43:23] Failed to create log directory           err="mkdir /var/log/go-ctidb: permission denied"                                               
INFO[06-15|15:43:23] Fetching mitre/cti                                                                                                                       
INFO[06-15|15:43:23] initializing                             repo=/home/otuki/.cache/go-ctidb/cti 
INFO[06-15|15:43:23] git clone                                repo=/home/otuki/.cache/go-ctidb/cti
Cloning into '/home/otuki/.cache/go-ctidb/cti'...
remote: Enumerating objects: 17094, done.                                                                                                                    
remote: Counting objects: 100% (17094/17094), done.                                                                                                          
remote: Compressing objects: 100% (7017/7017), done.                                                                                                         
remote: Total 17094 (delta 12433), reused 10241 (delta 10076), pack-reused 0                                                                                 
Receiving objects: 100% (17094/17094), 14.14 MiB | 282.00 KiB/s, done.                                                                                       
Resolving deltas: 100% (12433/12433), done.                                                                                                                  
INFO[06-15|15:44:20] Updated files                            count=17074                                  
  757 / 757 [======================================================================================================================================] 100.00% 0s 
  153 / 153 [======================================================================================================================================] 100.00% 0s
INFO[06-15|15:44:21] Cyber Threat Intelligence with CVEs      count=15070                                                                                    
INFO[06-15|15:44:21] Insert info into go-ctidb.               db=sqlite3                                                                                     
INFO[06-15|15:44:21] Inserting Threat Intelligences having CVEs...                                                                                            
15070 / 15070 [==================================================================================================================================] 100.00% 3s
INFO[06-15|15:44:24] CveID Metasploit Count                   count=15070
$
```

# Check

***Is this ready for review?:*** Yes
