### PR TITLE
fix(env-var): Command arguments are able to be set environment variable "GO_CTI_ARGS"

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,11 +18,8 @@ var version = "0.0.1"
 func main() {
 	var v = flag.Bool("v", false, "Show version")
 
-	if envArgs := os.Getenv("GOVAL_DICTIONARY_ARGS"); 0 < len(envArgs) {
-		if err := flag.CommandLine.Parse(strings.Fields(envArgs)); err != nil {
-			fmt.Printf("Failed to parse ENV_VARs: %s", err)
-			os.Exit(1)
-		}
+	if envArgs := os.Getenv("GO_CTI_ARGS"); 0 < len(envArgs) {
+		commands.RootCmd.SetArgs(strings.Fields(envArgs))
 	} else {
 		flag.Parse()
 	}


### PR DESCRIPTION
# What did you implement:

Command arguments of go-cti are able to be set environment variable "GO_CTI_ARGS" like below.

```bash
$ export GO_CTI_ARGS="fetch threat"

$ go run main.go
EROR[07-09|16:40:11] Failed to create log directory           err="mkdir /var/log/go-ctidb: permission denied"
INFO[07-09|16:40:11] Fetching mitre/cti
INFO[07-09|16:40:11] initializing                             repo=/home/otuki/.cache/go-ctidb/cti
INFO[07-09|16:40:11] git clone                                repo=/home/otuki/.cache/go-ctidb/cti
Cloning into '/home/otuki/.cache/go-ctidb/cti'...
remote: Enumerating objects: 17102, done.
remote: Counting objects: 100% (17102/17102), done.
remote: Compressing objects: 100% (7020/7020), done.
remote: Total 17102 (delta 12440), reused 10240 (delta 10081), pack-reused 0
Receiving objects: 100% (17102/17102), 14.14 MiB | 1.63 MiB/s, done.
Resolving deltas: 100% (12440/12440), done.
INFO[07-09|16:40:24] Updated files                            count=17082
 396 / 756 [==============================================>-----------------------------------------]  52.38% 0s
 77 / 152 [=============================================>-------------------------------------------]  50.66% 0s
INFO[07-09|16:40:25] Cyber Threat Intelligence with CVEs      count=13830
INFO[07-09|16:40:25] Insert info into go-ctidb.               db=sqlite3
INFO[07-09|16:40:25] Inserting Threat Intelligences having CVEs...
 13830 / 13830 [====================================================================================] 100.00% 2s
INFO[07-09|16:40:28] CveID Metasploit Count                   count=13830

$
```

# How Has This Been Tested?

```bash
$ export -n GO_CTI_ARGS

$ go run main.go
Go collect Cyber Threat Intelligence

Usage:
  go-cti [command]

Available Commands:
  fetch       Fetch the data of mitre/cti
  help        Help about any command

Flags:
      --config string       config file (default is $HOME/.go-cti.yaml)
      --dbpath string       /path/to/sqlite3 or SQL connection string
      --dbtype string       Database type to store data in (sqlite3, mysql, postgres or redis supported)
      --debug               debug mode (default: false)
      --debug-sql           SQL debug mode
  -h, --help                help for go-cti
      --http-proxy string   http://proxy-url:port (default: empty)
      --log-dir string      /path/to/log
      --log-json            output log as JSON
      --quiet               quiet mode (no output)

Use "go-cti [command] --help" for more information about a command.

$
```

# Check

***Is this ready for review?:*** Yes