### PR TITLE
feat(version): show version and revision of go-cti

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,18 +14,16 @@
 
 SRCS = $(shell git ls-files '*.go')
 PKGS = $(shell go list ./...)
-VERSION := $(shell git describe --tags --abbrev=0)
 REVISION := $(shell git rev-parse --short HEAD)
 BUILDTIME := $(shell date "+%Y%m%d_%H%M%S")
-LDFLAGS := -X 'main.version=$(VERSION)' \
-        -X 'main.revision=$(REVISION)'
+LDFLAGS := -X 'main.Revision=$(REVISION)'
 GO := GO111MODULE=on go
 GO_OFF := GO111MODULE=off go
 
 all: build
 
 build: main.go pretest fmt
-	$(GO) build -ldflags "$(LDFLAGS)" -o go-cti $<
+	$(GO) build -a -ldflags "$(LDFLAGS)" -o go-cti $<
 
 install: main.go
 	$(GO) install -ldflags "$(LDFLAGS)"

--- a/main.go
+++ b/main.go
@@ -12,8 +12,11 @@ import (
 // Name ... Name
 const Name string = "go-cti"
 
-// Version ... Version
-var version = "0.0.1"
+// Version of go-cti
+var Version = "0.0.0"
+
+// Revision of go-cti
+var Revision string
 
 func main() {
 	var v = flag.Bool("v", false, "Show version")
@@ -25,7 +28,7 @@ func main() {
 	}
 
 	if *v {
-		fmt.Printf("%s %s \n", Name, version)
+		fmt.Printf("go-cti %s %s\n", Version, Revision)
 		os.Exit(0)
 	}
 

--- a/models/models.go
+++ b/models/models.go
@@ -11,7 +11,7 @@ type LastUpdated struct {
 
 // Cti : Cyber Threat Intelligence
 type Cti struct {
-	ID          int64 `json:",omitempty"`
+	ID       int64 `gorm:"primary_key"`
 	Name        string
 	Type        string
 	Description string
@@ -25,6 +25,8 @@ type Cti struct {
 
 // Capec is Child model of Cti
 type Capec struct {
+	ID       int64 `gorm:"primary_key"`
+	CtiID    int64 `sql:"type:bigint REFERENCES ctis(id)"`
 	Abstruct string
 	Status   string
 	Severity string
@@ -34,12 +36,16 @@ type Capec struct {
 
 // KillChain is Child model of Cti
 type KillChain struct {
+	ID       int64 `gorm:"primary_key"`
+	CtiID    int64 `sql:"type:bigint REFERENCES ctis(id)"`
 	Name  string
 	Phase string
 }
 
 // Reference is Child model of Cti
 type Reference struct {
+	ID       int64 `gorm:"primary_key"`
+	CtiID    int64 `sql:"type:bigint REFERENCES ctis(id)"`
 	ExternalID  string
 	Link        string `sql:"type:text"`
 	Description string `sql:"type:text"`


### PR DESCRIPTION
# What did you implement:

Add new command "search", which is fucntion that get CVE information as below

```bash
$ make build
GO111MODULE=off go get -u golang.org/x/lint/golint
golint github.com/vulsio/go-cti github.com/vulsio/go-cti/commands github.com/vulsio/go-cti/db github.com/vulsio/go-cti/fetcher github.com/vulsio/go-cti/git github.com/vulsio/go-cti/models github.com/vulsio/go-cti/utils
echo github.com/vulsio/go-cti github.com/vulsio/go-cti/commands github.com/vulsio/go-cti/db github.com/vulsio/go-cti/fetcher github.com/vulsio/go-cti/git github.com/vulsio/go-cti/models github.com/vulsio/go-cti/utils | xargs env GO111MODULE=on go vet || exit;
gofmt -d commands/fetch-cti.go; gofmt -d commands/fetch.go; gofmt -d commands/root.go; gofmt -d commands/search.go; gofmt -d db/db.go; gofmt -d db/rdb.go; gofmt -d fetcher/mitre.go; gofmt -d fetcher/types.go; gofmt -d git/git.go; gofmt -d main.go; gofmt -d models/models.go; gofmt -d utils/utils.go; gofmt -d utils/utils_test.go;
gofmt -w commands/fetch-cti.go commands/fetch.go commands/root.go commands/search.go db/db.go db/rdb.go fetcher/mitre.go fetcher/types.go git/git.go main.go models/models.go utils/utils.go utils/utils_test.go
GO111MODULE=on go build -a -ldflags "-X 'main.Revision=7c3df2c'" -o go-cti main.go

$ ./go-cti -v
go-cti 0.0.0 7c3df2c
```



# How Has This Been Tested?

Ran `make build` and `make install`. 
After that, confirmed vesion and revision of go-cti.

The test of `make install` is run as below. 
 
```bash
$ make install
GO111MODULE=on go install -ldflags "-X 'main.Revision=7c3df2c'"

$ go-cti -v
go-cti 0.0.0 7c3df2c

```

# Check

***Is this ready for review?:*** Yes
