### PR TITLE
chore: print to stderr, fill version and fix redis fetch

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,6 +14,7 @@
 
 SRCS = $(shell git ls-files '*.go')
 PKGS = $(shell go list ./...)
+VERSION := $(shell git describe --tags --abbrev=0)
 REVISION := $(shell git rev-parse --short HEAD)
 BUILDTIME := $(shell date "+%Y%m%d_%H%M%S")
 LDFLAGS := -X 'github.com/vulsio/go-cti/config.Version=$(VERSION)' \

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -127,7 +127,7 @@ func (r *RDBDriver) MigrateDB() error {
 		&models.PermissionRequired{},
 		&models.EffectivePermission{},
 		&models.DefenseBypassed{},
-		&models.ImapctType{},
+		&models.ImpactType{},
 		&models.SubTechnique{},
 
 		&models.Capec{},
@@ -226,7 +226,7 @@ func (r *RDBDriver) deleteAndInsertCti(conn *gorm.DB, techniques []models.Techni
 		models.SoftwareUsed{}, models.AssociatedGroup{}, models.AttackerGroup{},
 		models.AttackerReference{}, models.TechniqueUsed{}, models.Attacker{},
 		models.RelatedWeakness{}, models.Consequence{}, models.SkillRequired{}, models.ResourceRequired{}, models.Prerequisite{}, models.ExampleInstance{}, models.AlternateTerm{}, models.Domain{}, models.Relationship{}, models.AttackID{}, models.Capec{},
-		models.SubTechnique{}, models.ImapctType{}, models.DefenseBypassed{}, models.EffectivePermission{}, models.PermissionRequired{}, models.TechniquePlatform{}, models.Procedure{}, models.DataSource{}, models.KillChainPhase{}, models.CapecID{}, models.MitreAttack{},
+		models.SubTechnique{}, models.ImpactType{}, models.DefenseBypassed{}, models.EffectivePermission{}, models.PermissionRequired{}, models.TechniquePlatform{}, models.Procedure{}, models.DataSource{}, models.KillChainPhase{}, models.CapecID{}, models.MitreAttack{},
 		models.Mitigation{}, models.TechniqueReference{}, models.Technique{},
 		models.CveToTechniqueID{}, models.CveToTechniques{},
 	} {

--- a/db/redis.go
+++ b/db/redis.go
@@ -269,6 +269,9 @@ func (r *RedisDriver) InsertCti(techniques []models.Technique, mappings []models
 			atkKey := fmt.Sprintf(atkIDKeyFormat, attacker.AttackerID)
 			if _, ok := newDeps["mapping"][attacker.AttackerID]; !ok {
 				newDeps["mapping"][attacker.AttackerID] = map[string]struct{}{}
+				if len(oldDeps["mapping"][attacker.AttackerID]) == 0 {
+					delete(oldDeps["mapping"], attacker.AttackerID)
+				}
 			}
 
 			for _, technique := range attacker.TechniquesUsed {

--- a/fetcher/attack/attack.go
+++ b/fetcher/attack/attack.go
@@ -263,7 +263,7 @@ func fillTechnique(attackPattern attackPattern, relationships []relationship, at
 			PermissionsRequired:  []models.PermissionRequired{},
 			EffectivePermissions: []models.EffectivePermission{},
 			DefenseBypassed:      []models.DefenseBypassed{},
-			ImpactType:           []models.ImapctType{},
+			ImpactType:           []models.ImpactType{},
 			NetworkRequirements:  attackPattern.networkRequirements,
 			RemoteSupport:        attackPattern.remoteSupport,
 			SubTechniques:        []models.SubTechnique{},
@@ -388,7 +388,7 @@ func fillTechnique(attackPattern attackPattern, relationships []relationship, at
 	}
 
 	for _, impactType := range attackPattern.impactType {
-		technique.MitreAttack.ImpactType = append(technique.MitreAttack.ImpactType, models.ImapctType{
+		technique.MitreAttack.ImpactType = append(technique.MitreAttack.ImpactType, models.ImpactType{
 			Type: impactType,
 		})
 	}

--- a/fetcher/attack/attack_test.go
+++ b/fetcher/attack/attack_test.go
@@ -167,7 +167,7 @@ func TestParse(t *testing.T) {
 						DefenseBypassed: []models.DefenseBypassed{
 							{Defense: "System Access Controls"},
 						},
-						ImpactType: []models.ImapctType{
+						ImpactType: []models.ImpactType{
 							{Type: "test"},
 						},
 						NetworkRequirements: true,
@@ -220,7 +220,7 @@ func TestParse(t *testing.T) {
 						},
 						EffectivePermissions: []models.EffectivePermission{},
 						DefenseBypassed:      []models.DefenseBypassed{},
-						ImpactType:           []models.ImapctType{},
+						ImpactType:           []models.ImpactType{},
 						SubTechniques:        []models.SubTechnique{},
 					},
 					Capec:    nil,

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	if err := commands.RootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	os.Exit(0)

--- a/models/models.go
+++ b/models/models.go
@@ -47,7 +47,7 @@ var (
 
 	// GroupType :
 	GroupType MitreAttackerType = "Group"
-	// Software :
+	// SoftwareType :
 	SoftwareType MitreAttackerType = "Software"
 
 	// MalwareType :
@@ -120,7 +120,7 @@ type MitreAttack struct {
 	PermissionsRequired  []PermissionRequired  `json:"permissions_required"`
 	EffectivePermissions []EffectivePermission `json:"effective_permissions"`
 	DefenseBypassed      []DefenseBypassed     `json:"defense_bypassed"`
-	ImpactType           []ImapctType          `json:"impact_type"`
+	ImpactType           []ImpactType          `json:"impact_type"`
 	NetworkRequirements  bool                  `json:"network_requirements"`
 	RemoteSupport        bool                  `json:"remote_support"`
 	SubTechniques        []SubTechnique        `json:"sub_techniques"`
@@ -185,7 +185,7 @@ type DefenseBypassed struct {
 }
 
 // ImpactType is Child model of MitreAttack
-type ImapctType struct {
+type ImpactType struct {
 	ID            int64  `json:"-"`
 	MitreAttackID int64  `gorm:"index:idx_impact_type_mitre_attack_id" json:"-"`
 	Type          string `gorm:"type:varchar(255)" json:"type"`


### PR DESCRIPTION
# What did you implement:

print to stderr, fill version and fix redis fetch.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```console
$ go-cti fetch threat --dbtype redis --dbpath "redis://127.0.0.1:6380" 1>/dev/null
Failed to open DB. err: dial tcp 127.0.0.1:6380: connect: connection refused
$ echo $?
1

$ go-cti version
go-cti v0.0.1 c30f2bd

$ docker run --rm -d -p 127.0.0.1:6379:6379 redis
$ go-cti fetch threat --dbtype redis --dbpath "redis://127.0.0.1:6379"
$ go-cti fetch threat --dbtype redis --dbpath "redis://127.0.0.1:6379"
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference
